### PR TITLE
Update list.html

### DIFF
--- a/partials/list.html
+++ b/partials/list.html
@@ -9,9 +9,9 @@
     </div>
     <ul class="media-items">
         <li class="media-item border border-radius cf" ng-repeat="item in medias | filter:mediaFilter | orderBy: mediaOrder:direction" ng-animate="'animate'">
-            <a href="{{item['link']['attributes']['href']}}" target="_blank">
+            <a ng-href="{{item['link']['attributes']['href']}}" target="_blank">
                 <div class="album-art left">
-                    <img src="{{item['im:image'][0]['label']}}" alt="Photo of {{item['im:name']['label']}} by {{item['im:artist']['label']}}">
+                    <img ng-src="{{item['im:image'][0]['label']}}" alt="Photo of {{item['im:name']['label']}} by {{item['im:artist']['label']}}">
                 </div>
                 <div class="info">
                     <span class="item-number">{{item['im:itemCount']['label']}}</span>


### PR DESCRIPTION
Using Angular markup like {{hash}} in a src attribute doesn't work right: The browser will fetch from the URL with the literal text {{hash}} until Angular replaces the expression inside {{hash}}. The ngSrc directive solves this problem.

Using Angular markup like {{hash}} in an href attribute will make the link go to the wrong URL if the user clicks it before Angular has a chance to replace the {{hash}} markup with its value. Until Angular replaces the markup the link will be broken and will most likely return a 404 error. The ngHref directive solves this problem.